### PR TITLE
Only allow Spacetime Auth connections

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,9 +1,23 @@
+/// OIDC Token Type Note:
+///
+/// - **Access Token**: Used for authorization to access protected resources.
+///   It may not contain the same claim structure and is not appropriate for
+///   this authentication validation.
+///
+/// - **ID Token**: Contains identity claims (issuer, audience, subject) and is
+///   intended for authentication. This is what SpacetimeAuth provides and what
+///   should be validated here.
+///
+/// The validation logic checks `issuer()` and `audience()` claims, which are
+/// standard ID token claims issued by the OIDC provider at
+/// `https://auth.spacetimedb.com/oidc`.
 use spacetimedb::ReducerContext;
 use spacetimedb::{reducer};
 
 
 pub mod modules;
 use modules::player::*;
+use modules::util::log_security_audit;
 use modules::*;
 
 pub mod schedulers;
@@ -17,20 +31,91 @@ fn database_init(ctx: &ReducerContext) {
 }
 
 
-// Set this to your the OIDC client (or set of clients) set up for your
-// SpacetimeAuth project.
-const OIDC_CLIENT_ID: &str = "client_031CVDRbDed69EKkv8duSe";
+// Set this to your OIDC client (or set of clients) set up for your
+// SpacetimeAuth project. You can override this default at compile time by
+// setting the `OIDC_CLIENT_ID` environment variable, e.g.:
+
+/// Called whenever a new client connection is established.
+///
+/// This lifecycle reducer enforces SpacetimeAuth-based authentication for
+/// incoming connections. The client must present a valid JWT issued by
+/// `https://auth.spacetimedb.com/oidc` whose audience list includes the
+/// configured OIDC client ID (`OIDC_CLIENT_ID`).
+///
+/// If the JWT is missing or fails validation (issuer or audience mismatch),
+/// this reducer returns an error and the host disconnects the client. On
+/// success, the connection is accepted and `handle_player_connection_event`
+/// is invoked to perform any additional player-specific initialization.
+const OIDC_CLIENT_ID: &str = match option_env!("OIDC_CLIENT_ID") {
+    Some(id) => id,
+    None => "client_031CVDRbDed69EKkv8duSe",
+};
+
+
 
 #[reducer(client_connected)]
-pub fn client_connected(ctx: &ReducerContext) -> Result<(), String> {
-    let jwt = ctx.sender_auth().jwt().ok_or("Authentication required".to_string())?;
-    if jwt.issuer() != "https://auth.spacetimedb.com/oidc" {
-        return Err("Invalid issuer".to_string());
-    }
+fn client_connected(ctx: &ReducerContext) -> Result<(), String> {
+    // Verify OIDC authentication if available
+    let auth = ctx.sender_auth();
 
-    if !jwt.audience().iter().any(|a| a == OIDC_CLIENT_ID) {
-        return Err("Invalid audience".to_string());
+
+    let client_jwt = auth.jwt();
+
+    match client_jwt {
+        None => {
+            spacetimedb::log::warn!("No JWT token provided by client");
+            let _ = log_security_audit(
+                ctx,
+                &format!(
+                    "Client connection rejected - missing JWT token. Client: {}",
+                    ctx.sender
+                ),
+            );
+            return Err("Missing JWT token".to_string());
+        }
+        Some(jwt) => {
+            spacetimedb::log::trace!("Validating JWT token");
+
+            
+            match jwt.issuer() {
+                issuer @ "https://auth.spacetimedb.com" => {
+                    spacetimedb::log::trace!("JWT contains issuer used by SpacetimeDB Maincloud Dashboard: {}", issuer);
+                }
+                issuer @ "https://auth.spacetimedb.com/oidc" => {
+                    spacetimedb::log::trace!("JWT Issuer: {}", issuer);
+                }
+                _ => {
+                    let _ = log_security_audit(
+                        ctx,
+                        &format!(
+                            "Client connection rejected - invalid OIDC issuer. Client: {}, Issuer: {}",
+                            ctx.sender,
+                            jwt.issuer()
+                        ),
+                    );
+                    return Err("Invalid issuer".to_string());
+                }
+            }
+
+            if !jwt.audience().iter().any(|a: &String| a == OIDC_CLIENT_ID || a == "spacetimedb") {
+                let _ = log_security_audit(
+                    ctx,
+                    &format!(
+                        "Client connection rejected - invalid audience claim. Client: {}, Raw: {}",
+                        ctx.sender,
+                        jwt.raw_payload()
+                    ),
+                );
+                return Err("Invalid audience".to_string());
+            }
+            spacetimedb::log::trace!(
+                "Client authenticated successfully via OIDC. Client: {}",
+                ctx.sender
+            );
+        }
     }
+   
+
     handle_player_connection_event(ctx, "connect");
     Ok(())
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -16,10 +16,23 @@ fn database_init(ctx: &ReducerContext) {
         .expect("Failed to initialize global configuration");
 }
 
-/// Handles client connection events, creating or updating player accounts.
+
+// Set this to your the OIDC client (or set of clients) set up for your
+// SpacetimeAuth project.
+const OIDC_CLIENT_ID: &str = "client_031CVDRbDed69EKkv8duSe";
+
 #[reducer(client_connected)]
-fn client_connected(ctx: &ReducerContext) {
+pub fn client_connected(ctx: &ReducerContext) -> Result<(), String> {
+    let jwt = ctx.sender_auth().jwt().ok_or("Authentication required".to_string())?;
+    if jwt.issuer() != "https://auth.spacetimedb.com/oidc" {
+        return Err("Invalid issuer".to_string());
+    }
+
+    if !jwt.audience().iter().any(|a| a == OIDC_CLIENT_ID) {
+        return Err("Invalid audience".to_string());
+    }
     handle_player_connection_event(ctx, "connect");
+    Ok(())
 }
 
 /// Handles client disconnection events, moving players to offline status.

--- a/server/src/modules/common.rs
+++ b/server/src/modules/common.rs
@@ -1,6 +1,7 @@
 use spacetimedb::ReducerContext;
 use spacetimedsl::dsl;
 
+use crate::modules::util::log_security_audit;
 
 /// Checks if the caller is either a developer or the server identity.
 pub fn try_server_or_dev(ctx: &ReducerContext) -> bool {
@@ -14,7 +15,10 @@ pub fn try_developer_only(ctx: &ReducerContext) -> bool {
         return true;
     }
     else {
-        log::warn!("SECURITY: Non-developer user {} attempted developer-only action", ctx.sender);
+        let _ = log_security_audit(
+            ctx,
+            &format!("Non-developer user {} attempted developer-only action", ctx.sender),
+        );
         return false;
     }
 }
@@ -25,7 +29,10 @@ pub fn try_server_only(ctx: &ReducerContext) -> bool {
         return true;
     }
     else {
-        log::warn!("SECURITY: Non-server user {} attempted server-only action", ctx.sender);
+        let _ = log_security_audit(
+            ctx,
+            &format!("Non-server user {} attempted server-only action", ctx.sender),
+        );
         return false;
     }
 }

--- a/server/src/modules/player.rs
+++ b/server/src/modules/player.rs
@@ -391,8 +391,16 @@ fn create_player_account(ctx: &ReducerContext, identity: Identity, username: Str
     })
         .map_err(|e| format!("Failed to create PlayerAccount: {:?}", e))?;
 
-
-    
+    // Audit the account creation
+    let _ = log_player_action_audit(
+        ctx,
+        &format!(
+            "Created PlayerAccount [{}] for identity [{}] with username [{}]",
+            player_account.get_id(),
+            identity,
+            username
+        ),
+    );
     
     Ok(player_account)
 }
@@ -453,15 +461,17 @@ pub fn set_username(ctx: &ReducerContext, t_username: String) -> Result<(), Stri
     }
     
     let mut requesting_user_account = dsl.get_player_account_by_identity(&ctx.sender)?;
+    let old_username = requesting_user_account.username.clone();
     requesting_user_account.username = normalised_username.clone();
     
 
     log_player_action_audit(
         ctx,
         &format!(
-            "Player [{}] (Identity: [{}]) set username to [{}]",
+            "Player [{}] (Identity: [{}]) changed username from [{}] to [{}]",
             &requesting_user_account.get_id(),
             &requesting_user_account.get_identity(),
+            &old_username,
             &normalised_username
         ),
     )?;

--- a/server/src/modules/roles.rs
+++ b/server/src/modules/roles.rs
@@ -5,6 +5,7 @@ use spacetimedsl::*;
 
 use crate::modules::player::*;
 use crate::modules::common::*;
+use crate::modules::util::log_security_audit;
 
 // Store User Roles
 #[dsl(plural_name = roles,
@@ -141,7 +142,10 @@ fn is_admin_tools_authorized(ctx: &ReducerContext) -> bool {
 pub fn set_player_roles(ctx: &ReducerContext, target_identity: Identity, requested_role: RoleType) -> Result<(), String> {
     if !try_server_or_dev(ctx) {
         if !is_admin_tools_authorized(ctx) {
-            log::warn!("SECURITY: Unauthorized attempt to set roles by {:?}", ctx.sender);
+            let _ = log_security_audit(
+                ctx,
+                &format!("Unauthorized attempt to set roles by {:?}", ctx.sender),
+            );
             return Err("Unauthorized access".to_string());
         }
     }

--- a/unit-tester/Cargo.lock
+++ b/unit-tester/Cargo.lock
@@ -93,6 +93,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,15 +243,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "client"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "hex",
  "lazy_static",
  "rand",
  "reqwest",
  "serde_json",
+ "sha2",
  "spacetimedb-sdk",
+ "tiny_http",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -767,6 +784,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1685,6 +1708,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2315,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/unit-tester/Cargo.toml
+++ b/unit-tester/Cargo.toml
@@ -8,5 +8,10 @@ spacetimedb-sdk = "1.11"
 hex = "0.4"
 rand = "0.9.1"
 lazy_static = "1.5.0"
-reqwest = { version = "*", features = ["blocking"] }
+reqwest = { version = "*", features = ["blocking", "json"] }
 serde_json = "1.0.142"
+tiny_http = "0.12"
+url = "2.4"
+sha2 = "0.10"
+base64 = "0.22"
+urlencoding = "2.1"


### PR DESCRIPTION
Implement authentication checks to ensure only valid Spacetime Auth connections are accepted, verifying both the issuer and audience of the JWT.